### PR TITLE
Uncomment 'users' app in INSTALLED_APPS

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -39,7 +39,7 @@ AUTH_USER_MODEL = 'users.CustomUser'
 # Application definition
 
 INSTALLED_APPS = [
-    # 'users',
+    'users',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',


### PR DESCRIPTION
Enable the 'users' app by uncommenting it in the settings.py file.